### PR TITLE
Fix: update theme workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
             - run: go version
 
             - name: Setup Hugo
-              uses: peaceiris/actions-hugo@v2
+              uses: peaceiris/actions-hugo@v3
               with:
                   hugo-version: "latest"
                   extended: true

--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 0.123.8
+          hugo-version: "latest"
           extended: true
 
       - name: Update theme


### PR DESCRIPTION
Stop the `update-theme` workflow from failing with:

```
Run hugo mod tidy
Error: "/tmp/hugo_cache_runner/modules/filecache/modules/pkg/mod/github.com/!cai!jimmy/hugo-theme-stack/v3@v3.34.1/layouts/partials/helper/color-from-str.html:4:1": parse failed: template: partials/helper/color-from-str.html:4: function "hash" not defined
```